### PR TITLE
feature: BaseForm

### DIFF
--- a/cjs/BaseForm/BaseForm.d.ts
+++ b/cjs/BaseForm/BaseForm.d.ts
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react';
+export declare type FormObject<T extends string> = Record<T, string | Blob>;
+/**
+ * This wraps around a FormData object to allow you specify which keys will be used.
+ * TypedFormData.fromForm<'foo' | 'bar'>(someHTMLElement);
+ */
+export declare class TypedFormData<T extends string> {
+    data: FormData;
+    constructor(formData: FormData);
+    toJS(): FormObject<T>;
+    static fromFormData<T extends string>(data: FormData): TypedFormData<T>;
+    static fromForm<T extends string>(target: EventTarget): TypedFormData<T>;
+}
+export interface BaseFormProps<T extends string> {
+    className?: string;
+    title: string;
+    onSubmit: (data: FormObject<T>) => void;
+    children: ReactNode;
+    button?: JSX.Element;
+    formId?: string;
+    submitDisabled?: boolean;
+}
+export declare const BaseForm: <T extends string>({ title, className, children, onSubmit, button, formId, submitDisabled, }: BaseFormProps<T>) => JSX.Element;

--- a/cjs/BaseForm/BaseForm.d.ts
+++ b/cjs/BaseForm/BaseForm.d.ts
@@ -14,10 +14,20 @@ export declare class TypedFormData<T extends string> {
 export interface BaseFormProps<T extends string> {
     className?: string;
     title: string;
+    /**
+     * This is the mechanism for bubbling up the values of the form.
+     */
     onSubmit: (data: FormObject<T>) => void;
     children: ReactNode;
+    /**
+     * Whatever component you pass here will be magically "disabled" if the form hasn't been
+     * modified or if you pass a true condition to the "submitDisabled" prop
+     */
     button?: JSX.Element;
     formId?: string;
+    /**
+     * Overrides the internal mechanism that decides whether to allow submission of the form or not.
+     */
     submitDisabled?: boolean;
 }
 export declare const BaseForm: <T extends string>({ title, className, children, onSubmit, button, formId, submitDisabled, }: BaseFormProps<T>) => JSX.Element;

--- a/cjs/BaseForm/BaseForm.jsx
+++ b/cjs/BaseForm/BaseForm.jsx
@@ -1,0 +1,86 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.BaseForm = exports.TypedFormData = void 0;
+const react_1 = __importStar(require("react"));
+/**
+ * This wraps around a FormData object to allow you specify which keys will be used.
+ * TypedFormData.fromForm<'foo' | 'bar'>(someHTMLElement);
+ */
+class TypedFormData {
+    constructor(formData) {
+        this.data = formData;
+    }
+    toJS() {
+        return Object.fromEntries([
+            ...this.data.entries(),
+        ]);
+    }
+    static fromFormData(data) {
+        return new TypedFormData(data);
+    }
+    static fromForm(target) {
+        return TypedFormData.fromFormData(new FormData(target));
+    }
+}
+exports.TypedFormData = TypedFormData;
+const getFormValueString = (form) => {
+    const elements = [...form.elements];
+    return elements
+        .map((e) => {
+        if (e.type === 'checkbox') {
+            return e.checked ? `${e.name}true` : `${e.name}`;
+        }
+        if ('value' in e) {
+            return e.name + e.value === '0' ? '' : e.value;
+        }
+        return '';
+    })
+        .join('');
+};
+const BaseForm = ({ title, className, children, onSubmit, button, formId, submitDisabled, }) => {
+    const formRef = (0, react_1.useRef)(null);
+    const [initialValue, setInitialValue] = (0, react_1.useState)('');
+    const [computedValue, setComputedValue] = (0, react_1.useState)('');
+    (0, react_1.useEffect)(() => {
+        if (formRef.current) {
+            setInitialValue(getFormValueString(formRef.current));
+        }
+    }, [formRef]);
+    const handleChange = (e) => {
+        const target = e.target;
+        if (target.form)
+            setComputedValue(getFormValueString(target.form));
+    };
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        return onSubmit(TypedFormData.fromForm(e.target).toJS());
+    };
+    const disabled = submitDisabled || computedValue === '' || computedValue === initialValue;
+    return (react_1.default.createElement("form", { id: formId, ref: formRef, "aria-label": title, onSubmit: handleSubmit, onChange: handleChange, className: className },
+        children,
+        button && react_1.default.cloneElement(button, { disabled })));
+};
+exports.BaseForm = BaseForm;

--- a/cjs/BaseForm/BaseForm.jsx
+++ b/cjs/BaseForm/BaseForm.jsx
@@ -46,6 +46,10 @@ class TypedFormData {
     }
 }
 exports.TypedFormData = TypedFormData;
+/**
+ * This component presents a (relatively) typesafe way of working with HTML forms.
+ * No external state management is required.
+ */
 const getFormValueString = (form) => {
     const elements = [...form.elements];
     return elements
@@ -78,7 +82,9 @@ const BaseForm = ({ title, className, children, onSubmit, button, formId, submit
         e.preventDefault();
         return onSubmit(TypedFormData.fromForm(e.target).toJS());
     };
-    const disabled = submitDisabled || computedValue === '' || computedValue === initialValue;
+    const disabled = submitDisabled !== undefined
+        ? submitDisabled
+        : computedValue === '' || computedValue === initialValue;
     return (react_1.default.createElement("form", { id: formId, ref: formRef, "aria-label": title, onSubmit: handleSubmit, onChange: handleChange, className: className },
         children,
         button && react_1.default.cloneElement(button, { disabled })));

--- a/esm/BaseForm/BaseForm.d.ts
+++ b/esm/BaseForm/BaseForm.d.ts
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react';
+export declare type FormObject<T extends string> = Record<T, string | Blob>;
+/**
+ * This wraps around a FormData object to allow you specify which keys will be used.
+ * TypedFormData.fromForm<'foo' | 'bar'>(someHTMLElement);
+ */
+export declare class TypedFormData<T extends string> {
+    data: FormData;
+    constructor(formData: FormData);
+    toJS(): FormObject<T>;
+    static fromFormData<T extends string>(data: FormData): TypedFormData<T>;
+    static fromForm<T extends string>(target: EventTarget): TypedFormData<T>;
+}
+export interface BaseFormProps<T extends string> {
+    className?: string;
+    title: string;
+    onSubmit: (data: FormObject<T>) => void;
+    children: ReactNode;
+    button?: JSX.Element;
+    formId?: string;
+    submitDisabled?: boolean;
+}
+export declare const BaseForm: <T extends string>({ title, className, children, onSubmit, button, formId, submitDisabled, }: BaseFormProps<T>) => JSX.Element;

--- a/esm/BaseForm/BaseForm.d.ts
+++ b/esm/BaseForm/BaseForm.d.ts
@@ -14,10 +14,20 @@ export declare class TypedFormData<T extends string> {
 export interface BaseFormProps<T extends string> {
     className?: string;
     title: string;
+    /**
+     * This is the mechanism for bubbling up the values of the form.
+     */
     onSubmit: (data: FormObject<T>) => void;
     children: ReactNode;
+    /**
+     * Whatever component you pass here will be magically "disabled" if the form hasn't been
+     * modified or if you pass a true condition to the "submitDisabled" prop
+     */
     button?: JSX.Element;
     formId?: string;
+    /**
+     * Overrides the internal mechanism that decides whether to allow submission of the form or not.
+     */
     submitDisabled?: boolean;
 }
 export declare const BaseForm: <T extends string>({ title, className, children, onSubmit, button, formId, submitDisabled, }: BaseFormProps<T>) => JSX.Element;

--- a/esm/BaseForm/BaseForm.jsx
+++ b/esm/BaseForm/BaseForm.jsx
@@ -19,6 +19,10 @@ export class TypedFormData {
         return TypedFormData.fromFormData(new FormData(target));
     }
 }
+/**
+ * This component presents a (relatively) typesafe way of working with HTML forms.
+ * No external state management is required.
+ */
 const getFormValueString = (form) => {
     const elements = [...form.elements];
     return elements
@@ -51,7 +55,9 @@ export const BaseForm = ({ title, className, children, onSubmit, button, formId,
         e.preventDefault();
         return onSubmit(TypedFormData.fromForm(e.target).toJS());
     };
-    const disabled = submitDisabled || computedValue === '' || computedValue === initialValue;
+    const disabled = submitDisabled !== undefined
+        ? submitDisabled
+        : computedValue === '' || computedValue === initialValue;
     return (React.createElement("form", { id: formId, ref: formRef, "aria-label": title, onSubmit: handleSubmit, onChange: handleChange, className: className },
         children,
         button && React.cloneElement(button, { disabled })));

--- a/esm/BaseForm/BaseForm.jsx
+++ b/esm/BaseForm/BaseForm.jsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useRef, useState, } from 'react';
+/**
+ * This wraps around a FormData object to allow you specify which keys will be used.
+ * TypedFormData.fromForm<'foo' | 'bar'>(someHTMLElement);
+ */
+export class TypedFormData {
+    constructor(formData) {
+        this.data = formData;
+    }
+    toJS() {
+        return Object.fromEntries([
+            ...this.data.entries(),
+        ]);
+    }
+    static fromFormData(data) {
+        return new TypedFormData(data);
+    }
+    static fromForm(target) {
+        return TypedFormData.fromFormData(new FormData(target));
+    }
+}
+const getFormValueString = (form) => {
+    const elements = [...form.elements];
+    return elements
+        .map((e) => {
+        if (e.type === 'checkbox') {
+            return e.checked ? `${e.name}true` : `${e.name}`;
+        }
+        if ('value' in e) {
+            return e.name + e.value === '0' ? '' : e.value;
+        }
+        return '';
+    })
+        .join('');
+};
+export const BaseForm = ({ title, className, children, onSubmit, button, formId, submitDisabled, }) => {
+    const formRef = useRef(null);
+    const [initialValue, setInitialValue] = useState('');
+    const [computedValue, setComputedValue] = useState('');
+    useEffect(() => {
+        if (formRef.current) {
+            setInitialValue(getFormValueString(formRef.current));
+        }
+    }, [formRef]);
+    const handleChange = (e) => {
+        const target = e.target;
+        if (target.form)
+            setComputedValue(getFormValueString(target.form));
+    };
+    const handleSubmit = (e) => {
+        e.preventDefault();
+        return onSubmit(TypedFormData.fromForm(e.target).toJS());
+    };
+    const disabled = submitDisabled || computedValue === '' || computedValue === initialValue;
+    return (React.createElement("form", { id: formId, ref: formRef, "aria-label": title, onSubmit: handleSubmit, onChange: handleChange, className: className },
+        children,
+        button && React.cloneElement(button, { disabled })));
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transmish",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "React utility library",
   "repository": "git@github.com:cargurus/transmish.git",
   "author": "Ian Schwartz <ischwartz@cargurus.com>",

--- a/src/BaseForm/BaseForm.spec.tsx
+++ b/src/BaseForm/BaseForm.spec.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event/dist';
+import BaseForm, { buttonText } from './BaseForm';
+
+describe('BaseForm Tests', () => {
+    it('should render a BaseForm', () => {
+        const onClick = jest.fn();
+        render(<BaseForm onClick={onClick} />);
+
+        const btn = screen.getByRole('button', { name: buttonText });
+        expect(btn).toBeInTheDocument();
+
+        userEvent.click(btn);
+        expect(onClick).toHaveBeenCalled();
+    });
+});

--- a/src/BaseForm/BaseForm.spec.tsx
+++ b/src/BaseForm/BaseForm.spec.tsx
@@ -1,17 +1,36 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event/dist';
-import BaseForm, { buttonText } from './BaseForm';
+import { BaseForm } from './BaseForm';
 
 describe('BaseForm Tests', () => {
     it('should render a BaseForm', () => {
-        const onClick = jest.fn();
-        render(<BaseForm onClick={onClick} />);
+        const onSubmit = jest.fn();
+        render(
+            <BaseForm
+                onSubmit={onSubmit}
+                button={<button type="submit">submit</button>}
+                title="cool"
+            >
+                <input name="foo" />
+                <input name="cool" value="yes" type="checkbox" />
+            </BaseForm>
+        );
 
-        const btn = screen.getByRole('button', { name: buttonText });
-        expect(btn).toBeInTheDocument();
+        const btn = screen.getByRole('button', {
+            name: 'submit',
+        }) as HTMLButtonElement;
+        expect(btn.disabled).toBeTruthy();
 
+        userEvent.type(screen.getByRole('textbox'), 'bar');
+        userEvent.click(screen.getByRole('checkbox'));
+
+        expect(btn.disabled).toBeFalsy();
         userEvent.click(btn);
-        expect(onClick).toHaveBeenCalled();
+
+        expect(onSubmit).toHaveBeenCalledWith({
+            foo: 'bar',
+            cool: 'yes',
+        });
     });
 });

--- a/src/BaseForm/BaseForm.stories.tsx
+++ b/src/BaseForm/BaseForm.stories.tsx
@@ -71,7 +71,7 @@ export const ControlledInput: ComponentStory<typeof BaseForm> = () => {
             }
         >
             <h3>
-        Sometimes you'll want to use controlled inputs for custom validations
+        Sometimes you will want to use controlled inputs for custom validations
             </h3>
       Enter any word more than 5 letters
             <input
@@ -81,12 +81,12 @@ export const ControlledInput: ComponentStory<typeof BaseForm> = () => {
                 required
             />
             {longWord.length > 0 && longWord.length < 5 && (
-                <div style={{ color: 'red' }}>That word isn't long enough</div>
+                <div style={{ color: 'red' }}>That word is not long enough</div>
             )}
             <br />
             <label>
         Are you Eddie Dingle <br />
-        Yes <br/>
+        Yes <br />
                 <input
                     type="radio"
                     name="eddieDingle"
@@ -95,7 +95,7 @@ export const ControlledInput: ComponentStory<typeof BaseForm> = () => {
                     onClick={() => setEddie(true)}
                 />
                 <br />
-        No <br/>
+        No <br />
                 <input
                     type="radio"
                     name="eddieDingle"

--- a/src/BaseForm/BaseForm.stories.tsx
+++ b/src/BaseForm/BaseForm.stories.tsx
@@ -1,0 +1,119 @@
+import React, { useState } from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { BaseForm, FormObject } from './BaseForm';
+
+export default {
+    title: 'BaseForm',
+    component: BaseForm,
+} as ComponentMeta<typeof BaseForm>;
+
+type FormFields =
+  | 'firstName'
+  | 'lastName'
+  | 'optInEmail'
+  | 'rootCanal'
+  | 'eddieDingle';
+
+export const UncontrolledInputs: ComponentStory<typeof BaseForm> = () => {
+    const [formData, setFormData] = useState<FormObject<FormFields>>();
+    return (
+        <BaseForm<FormFields>
+            title="Uncontrolled Inputs"
+            onSubmit={(data) => setFormData(data)}
+        >
+            <h3>All inputs are uncontrolled</h3>
+            <input name="firstName" placeholder="first name" required />
+            <input name="lastName" placeholder="last name" required />
+            <br />
+
+            <label>
+        I would like to receive emails <br />
+                <input type="checkbox" value="true" name="optInEmail" required />
+            </label>
+            <br />
+
+            <label>
+        I would like to get a root canal <br />
+                <input type="checkbox" value="true" name="rootCanal" required />
+            </label>
+            <br />
+
+            <label>
+        Are you Eddie Dingle? <br />
+        Yes <input type="radio" name="eddieDingle" value="true" />
+                <br />
+        No <input type="radio" name="eddieDingle" value="false" />
+            </label>
+            <br />
+
+            <button type="submit">submit</button>
+            <h3>Output:</h3>
+            <pre>
+                <code>{JSON.stringify(formData, null, '\t')}</code>
+            </pre>
+        </BaseForm>
+    );
+};
+
+type OtherFields = 'longWord' | 'shortWord';
+export const ControlledInput: ComponentStory<typeof BaseForm> = () => {
+    const [formData, setFormData] = useState<FormObject<OtherFields>>();
+    const [longWord, setLongWord] = useState<string>('');
+    const [eddie, setEddie] = useState<boolean>();
+
+    return (
+        <BaseForm
+            title="Uncontrolled Inputs"
+            onSubmit={(data) => setFormData(data)}
+            button={<button type="submit">submit</button>}
+            submitDisabled={
+                eddie === true || eddie === undefined || longWord.length < 5
+            }
+        >
+            <h3>
+        Sometimes you'll want to use controlled inputs for custom validations
+            </h3>
+      Enter any word more than 5 letters
+            <input
+                name="longWord"
+                value={longWord}
+                onChange={(e) => setLongWord(e.target.value)}
+                required
+            />
+            {longWord.length > 0 && longWord.length < 5 && (
+                <div style={{ color: 'red' }}>That word isn't long enough</div>
+            )}
+            <br />
+            <label>
+        Are you Eddie Dingle <br />
+        Yes <br/>
+                <input
+                    type="radio"
+                    name="eddieDingle"
+                    value="true"
+                    checked={eddie === true}
+                    onClick={() => setEddie(true)}
+                />
+                <br />
+        No <br/>
+                <input
+                    type="radio"
+                    name="eddieDingle"
+                    value="false"
+                    checked={eddie === false}
+                    onClick={() => setEddie(false)}
+                />
+            </label>
+            {eddie === true && (
+                <div style={{ color: 'red' }}>
+          Sorry Charlie, Eddie Dingle is not allowed
+                </div>
+            )}
+            <br />
+            <h3>Output:</h3>
+            <pre>
+                <code>{JSON.stringify(formData, null, '\t')}</code>
+            </pre>
+        </BaseForm>
+    );
+};

--- a/src/BaseForm/BaseForm.tsx
+++ b/src/BaseForm/BaseForm.tsx
@@ -7,6 +7,7 @@ import React, {
 } from 'react';
 
 export type FormObject<T extends string> = Record<T, string | Blob>;
+
 /**
  * This wraps around a FormData object to allow you specify which keys will be used.
  * TypedFormData.fromForm<'foo' | 'bar'>(someHTMLElement);
@@ -37,13 +38,27 @@ export class TypedFormData<T extends string> {
 export interface BaseFormProps<T extends string> {
   className?: string;
   title: string;
+  /**
+   * This is the mechanism for bubbling up the values of the form.
+   */
   onSubmit: (data: FormObject<T>) => void;
   children: ReactNode;
+  /**
+   * Whatever component you pass here will be magically "disabled" if the form hasn't been
+   * modified or if you pass a true condition to the "submitDisabled" prop
+   */
   button?: JSX.Element;
   formId?: string;
+  /**
+   * Overrides the internal mechanism that decides whether to allow submission of the form or not.
+   */
   submitDisabled?: boolean;
 }
 
+/**
+ * This component presents a (relatively) typesafe way of working with HTML forms.
+ * No external state management is required.
+ */
 const getFormValueString = (form: HTMLFormElement): string => {
     const elements = [...form.elements] as HTMLInputElement[];
     return elements
@@ -92,7 +107,9 @@ export const BaseForm = <T extends string>({
     };
 
     const disabled: boolean =
-    submitDisabled || computedValue === '' || computedValue === initialValue;
+    submitDisabled !== undefined
+        ? submitDisabled
+        : computedValue === '' || computedValue === initialValue;
 
     return (
         <form

--- a/src/BaseForm/BaseForm.tsx
+++ b/src/BaseForm/BaseForm.tsx
@@ -1,0 +1,110 @@
+import React, {
+    FormEventHandler,
+    ReactNode,
+    useEffect,
+    useRef,
+    useState,
+} from 'react';
+
+export type FormObject<T extends string> = Record<T, string | Blob>;
+/**
+ * This wraps around a FormData object to allow you specify which keys will be used.
+ * TypedFormData.fromForm<'foo' | 'bar'>(someHTMLElement);
+ */
+export class TypedFormData<T extends string> {
+    data: FormData;
+    constructor(formData: FormData) {
+        this.data = formData;
+    }
+
+    toJS(): FormObject<T> {
+        return Object.fromEntries([
+            ...this.data.entries(),
+        ]) as unknown as FormObject<T>;
+    }
+
+    static fromFormData<T extends string>(data: FormData) {
+        return new TypedFormData<T>(data);
+    }
+
+    static fromForm<T extends string>(target: EventTarget) {
+        return TypedFormData.fromFormData<T>(
+            new FormData(target as HTMLFormElement)
+        );
+    }
+}
+
+export interface BaseFormProps<T extends string> {
+  className?: string;
+  title: string;
+  onSubmit: (data: FormObject<T>) => void;
+  children: ReactNode;
+  button?: JSX.Element;
+  formId?: string;
+  submitDisabled?: boolean;
+}
+
+const getFormValueString = (form: HTMLFormElement): string => {
+    const elements = [...form.elements] as HTMLInputElement[];
+    return elements
+        .map((e) => {
+            if (e.type === 'checkbox') {
+                return e.checked ? `${e.name}true` : `${e.name}`;
+            }
+            if ('value' in e) {
+                return e.name + e.value === '0' ? '' : e.value;
+            }
+            return '';
+        })
+        .join('');
+};
+
+export const BaseForm = <T extends string>({
+    title,
+    className,
+    children,
+    onSubmit,
+    button,
+    formId,
+    submitDisabled,
+}: BaseFormProps<T>) => {
+    const formRef = useRef<HTMLFormElement>(null);
+    const [initialValue, setInitialValue] = useState('');
+    const [computedValue, setComputedValue] = useState('');
+
+    useEffect(() => {
+        if (formRef.current) {
+            setInitialValue(getFormValueString(formRef.current));
+        }
+    }, [formRef]);
+
+    const handleChange: FormEventHandler = (e) => {
+        const target = e.target as HTMLInputElement;
+        if (target.form) setComputedValue(getFormValueString(target.form));
+    };
+
+    const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
+        e.preventDefault();
+
+        return onSubmit(
+      TypedFormData.fromForm<T>(e.target).toJS() as FormObject<T>
+        );
+    };
+
+    const disabled: boolean =
+    submitDisabled || computedValue === '' || computedValue === initialValue;
+
+    return (
+        <form
+            id={formId}
+            ref={formRef}
+            aria-label={title}
+            onSubmit={handleSubmit}
+            onChange={handleChange}
+            className={className}
+        >
+            {children}
+            {button && React.cloneElement(button, { disabled })}
+        </form>
+    );
+};

--- a/src/BaseForm/styles.less
+++ b/src/BaseForm/styles.less
@@ -1,4 +1,0 @@
-.btn {
-    display: block;
-}
-

--- a/src/BaseForm/styles.less
+++ b/src/BaseForm/styles.less
@@ -1,0 +1,4 @@
+.btn {
+    display: block;
+}
+


### PR DESCRIPTION
This component has managed to cover almost all of my use-cases for forms for a couple of months now, and I think it deserves a place in this library.

Specifically, this component is designed to eliminate or reduce the need for state management for forms. IMO, uncontrolled forms should usually be the default, with validations happening the component level, as low in the tree as possible. This does not prevent the use of Formik or react-form or whatever, but presents a smoother interface to the native HTML form. There is no CSS associated with this form, but you can add your own with the `className` prop.

NOTE TO REVIEWERS: Any js/d.ts files not in the src folder are generated by typescript.

https://github.com/cargurus/transmish/assets/56884088/8e2debb8-f84d-42c6-9146-1fd7a19c9967


https://github.com/cargurus/transmish/assets/56884088/ff722a40-af3f-43ec-9bc8-3e9fe5ea5c87

